### PR TITLE
Added support for bash

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ import logging
 import gi
 import docker
 
-from ulauncher.api.shared.event import KeywordQueryEvent, ItemEnterEvent
+from ulauncher.api.shared.event import KeywordQueryEvent, ItemEnterEvent, PreferencesUpdateEvent, PreferencesEvent
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.client.Extension import Extension
 from gi.repository import Notify
@@ -32,6 +32,8 @@ class DockerExtension(Extension):
         self.docker_client = docker.from_env()
         self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
         self.subscribe(ItemEnterEvent, ItemEnterEventListener())
+        self.subscribe(PreferencesUpdateEvent, PreferencesUpdateEventListener())
+        self.subscribe(PreferencesEvent, PreferencesEventListener())
 
         parser = ArgumentParser()
         parser.add_argument('-c', '--c', action='store', dest='container_id')
@@ -150,6 +152,19 @@ class ItemEnterEventListener(EventListener):
         if data['action'] == ACTION_START_CONTAINER:
             LOGGING.info("Starting container %s", data['id'])
             extension.start_container(data['id'])
+
+
+class PreferencesUpdateEventListener(EventListener):
+
+    def on_event(self, event, extension):
+
+        if event.id == "shel_type":
+            extension.shel_type = event.new_value
+
+class PreferencesEventListener(EventListener):
+
+    def on_event(self, event, extension):
+        extension.shell_type = event.preferences["shell_type"]
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -158,8 +158,8 @@ class PreferencesUpdateEventListener(EventListener):
 
     def on_event(self, event, extension):
 
-        if event.id == "shel_type":
-            extension.shel_type = event.new_value
+        if event.id == "shell_type":
+            extension.shell_type = event.new_value
 
 class PreferencesEventListener(EventListener):
 

--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,23 @@
       "name": "Docker",
       "description": "List Docker containers",
       "default_value": "dk"
+    },
+    {
+      "id": "shell_type",
+      "type": "select",
+      "name": "Type of shell",
+      "description": "List Docker containers",
+      "options": [
+        {
+          "value": "bash",
+          "text": "bash"
+        },
+        {
+          "value": "sh",
+          "text": "sh"
+        }
+      ],
+      "default_value": "sh"
     }
   ]
 }

--- a/views/container_details.py
+++ b/views/container_details.py
@@ -93,17 +93,17 @@ class ContainerDetailsView():
             items.append(
                 ExtensionResultItem(
                     icon='images/icon_terminal.png',
-                    name="Open container shell",
-                    description="Opens a new sh shell in the container",
+                    name="Open container in {0}".format(self.extension.shell_type),
+                    description="Opens a new {0} terminal in the container".format(self.extension.shell_type),
                     highlightable=False,
                     on_enter=RunScriptAction(
-                        "x-terminal-emulator -e docker exec -it %s sh" %
+                        "x-terminal-emulator -e docker exec -it %s {0}".format(self.extension.shell_type) %
                         container.short_id, [])))
 
             items.append(
                 ExtensionResultItem(icon='images/icon_stop.png',
                                     name="Stop",
-                                    description="Stops The container",
+                                    description="Stops the container",
                                     highlightable=False,
                                     on_enter=ExtensionCustomAction({
                                         'action':


### PR DESCRIPTION
While this extension is really useful, it has one missing feature: be able to open a Docker container using bash instead of sh.

This was also requested in #2.

So, this pull request adds the option to open a container using bash and sh. The default shell can be changed in the settings.

Hope this helps!